### PR TITLE
fix: atualizar variáveis de ambiente para usar segredos do GitHub

### DIFF
--- a/.github/workflows/deploy-aws.yaml
+++ b/.github/workflows/deploy-aws.yaml
@@ -8,7 +8,7 @@ on:
 env:
   AWS_REGION: us-west-2
   CLUSTER_NAME: eks-fiap-soat10-prod
-  AWS_ACCOUNT_ID: 578625597971
+  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
 
 jobs:
   deploy-production:
@@ -22,7 +22,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           aws-region: ${{ env.AWS_REGION }}
 


### PR DESCRIPTION
This pull request updates the AWS deployment workflow to enhance security by replacing hardcoded values with GitHub secrets and correcting a misnamed secret. 

### Security improvements:

* [`.github/workflows/deploy-aws.yaml`](diffhunk://#diff-45b8cb50925a04561a77ea418b7cc5610adf8ed759a9168f87ee0905a117efa4L11-R11): Replaced the hardcoded `AWS_ACCOUNT_ID` with the GitHub secret `${{ secrets.AWS_ACCOUNT_ID }}` to prevent exposing sensitive information.
* [`.github/workflows/deploy-aws.yaml`](diffhunk://#diff-45b8cb50925a04561a77ea418b7cc5610adf8ed759a9168f87ee0905a117efa4L25-R25): Corrected the secret name for `aws-secret-access-key` from `${{ secrets.AWS_SECRET_ID }}` to `${{ secrets.AWS_SECRET_ACCESS_KEY }}` to align with the intended secret naming convention.