### PR TITLE
fix: reativar etapa de BuildAndPush no pipeline de deploy e remover d…

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,11 +34,11 @@ jobs:
           --password-stdin \
           ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
 
-      # - name: BuildAndPush Dockerfile
-      #   run: |
-      #     docker build -t ${{ env.AWS_ECR_NAME }} . && \
-      #     docker tag ${{ env.AWS_ECR_NAME }}:latest ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.AWS_ECR_NAME }}:latest && \
-      #     docker push ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.AWS_ECR_NAME }}:latest
+      - name: BuildAndPush Dockerfile
+        run: |
+          docker build -t ${{ env.AWS_ECR_NAME }} . && \
+          docker tag ${{ env.AWS_ECR_NAME }}:latest ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.AWS_ECR_NAME }}:latest && \
+          docker push ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.AWS_ECR_NAME }}:latest
 
       - name: Update Kube Config
         run: |
@@ -50,11 +50,10 @@ jobs:
         env:
           IMAGE: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.AWS_ECR_NAME }}:latest
         run: |
+          kubectl apply -f k8s/configmap.yaml
           export BASE64_ACCESS_KEY_ID=$(echo "${{ secrets.AWS_ACCESS_KEY_ID }}" | base64)
           export BASE64_SECRET_ACCESS_KEY=$(echo "${{ secrets.AWS_SECRET_ACCESS_KEY }}" | base64)
           export BASE64_SESSION_TOKEN=$(echo "${{ secrets.AWS_SESSION_TOKEN }}" | base64 -w 0)
-
-          kubectl apply -f k8s/configmap.yaml
           envsubst < k8s/secret.yaml | kubectl apply -f -
           envsubst < k8s/deployment-app.yaml | kubectl apply -f -
           kubectl apply -f k8s/service.yaml


### PR DESCRIPTION
This pull request updates the `.github/workflows/push.yaml` file to fix and streamline the deployment workflow. The most important changes include re-enabling the Docker image build and push step and ensuring the Kubernetes `configmap.yaml` is applied at the correct point in the workflow.

### Workflow improvements:

* Re-enabled the `BuildAndPush Dockerfile` step in the workflow by uncommenting and reformatting the relevant commands to build, tag, and push the Docker image to AWS Elastic Container Registry (ECR).
* Moved the `kubectl apply -f k8s/configmap.yaml` command to an earlier point in the deployment step, ensuring that the Kubernetes ConfigMap is applied before other resources like secrets and deployments.…uplicação do Kube Apply